### PR TITLE
Dynamic creation and update of `Last updated` notice 

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,3 +1,4 @@
 default: true
-MD013: false  # Disable line length limit
-MD033: false  # Allow inline HTML
+MD013: false # Disable line length limit
+MD033: false # Allow inline HTML
+MD036: false # Disable Emphasis used instead of a header

--- a/docs/Contributors.md
+++ b/docs/Contributors.md
@@ -1,5 +1,7 @@
 # Contributors
 
+_Last updated: 2025-05-14_
+
 | Contributor                                         |
 | --------------------------------------------------- |
 | [Ana Franco](https://github.com/afrancoc2000)       |

--- a/docs/Introduction.md
+++ b/docs/Introduction.md
@@ -1,5 +1,7 @@
 # Introduction
 
+_Last updated: 2025-05-16_
+
 Generative AI is shifting rapidly from research to production, with enterprises
 seeking robust, maintainable and scalable solutions to solve complex problems.
 In this landscape, the design of multi-agent systems, where numerous specialized

--- a/docs/References.md
+++ b/docs/References.md
@@ -1,5 +1,7 @@
 # References
 
+_Last updated: 2025-05-29_
+
 ## Orchestration
 
 - [Semantic Kernel: Multi-agent Orchestration](https://devblogs.microsoft.com/semantic-kernel/semantic-kernel-multi-agent-orchestration/)

--- a/docs/agent-registry/Agent-Registry.md
+++ b/docs/agent-registry/Agent-Registry.md
@@ -1,5 +1,7 @@
 # Agent Registry
 
+_Last updated: 2025-05-15_
+
 Agent Registry is the component that contains the information regarding
 available agents in the multi-agent system.
 

--- a/docs/agents-communication/Agents-Communication.md
+++ b/docs/agents-communication/Agents-Communication.md
@@ -1,5 +1,7 @@
 # Agents Communication
 
+_Last updated: 2025-05-15_
+
 As the ecosystem of AI agents rapidly evolves, new protocols are emerging to
 support diverse communication needs, security models, and integration patterns.
 These protocols—ranging from centralized to fully decentralized approaches—are

--- a/docs/building-blocks/Building-Blocks.md
+++ b/docs/building-blocks/Building-Blocks.md
@@ -1,5 +1,7 @@
 # Building Blocks
 
+_Last updated: 2025-05-28_
+
 ## Core components
 
 ```mermaid

--- a/docs/design-options/Design-Options.md
+++ b/docs/design-options/Design-Options.md
@@ -1,5 +1,7 @@
 # Multi-agent Design Options
 
+_Last updated: 2025-05-15_
+
 This chapter explores architectural strategies for building multi-agent systems.
 Here we break down two primary design approaches:
 

--- a/docs/design-options/Microservices.md
+++ b/docs/design-options/Microservices.md
@@ -1,5 +1,7 @@
 # Agents as Microservices
 
+_Last updated: 2025-05-16_
+
 In the microservices design, each component—such as the orchestrator and every
 specialized agent—is encapsulated as an independent service running within its
 own process, potentially on separate machines or cloud services. These agents

--- a/docs/design-options/Modular-Monolith.md
+++ b/docs/design-options/Modular-Monolith.md
@@ -1,5 +1,7 @@
 # Agents as a Modular Monolith
 
+_Last updated: 2025-05-15_
+
 In the modular monolith design, all components—the orchestrator and each
 specialized agent—reside within a single codebase and are deployed as one
 application. While they are logically decoupled as independent modules or

--- a/docs/governance/Experimentation-To-Productization.md
+++ b/docs/governance/Experimentation-To-Productization.md
@@ -1,5 +1,7 @@
 # Experimentation to Productization
 
+_Last updated: 2025-05-29_
+
 This document outlines the process of transitioning an agent from
 experimentation to production. It defines the key steps required to ensure that
 an agent is reliable, performant, secure, and observable in real-world

--- a/docs/governance/Governance.md
+++ b/docs/governance/Governance.md
@@ -1,5 +1,7 @@
 # Governance
 
+_Last updated: 2025-05-13_
+
 One of the key aspects of adopting any new technology in an enterprise
 environment is governance. This becomes even more critical with the adoption of
 Generative AI (GenAI). While GenAI represents a powerful and transformative

--- a/docs/memory/Memory.md
+++ b/docs/memory/Memory.md
@@ -1,5 +1,7 @@
 # Memory
 
+_Last updated: 2025-05-18_
+
 Memory is a foundational aspect of multi-agent systems, shaping how agents
 understand context, make decisions, and collaborate effectively. This chapter
 introduces two core memory types in multi-agent systems:

--- a/docs/memory/Short-Term-Memory.md
+++ b/docs/memory/Short-Term-Memory.md
@@ -2,6 +2,8 @@
 
 # Short-term Memory
 
+_Last updated: 2025-05-26_
+
 When building the STM (Short-Term Memory) layer for a multi-agent system, the
 storage engine choice is critical. STM typically serves to persist conversation
 history, contextual state, and intermediary data that agents use to manage

--- a/docs/observability/Observability.md
+++ b/docs/observability/Observability.md
@@ -1,5 +1,7 @@
 # Observability
 
+_Last updated: 2025-05-13_
+
 As AI solutions evolve into complex, distributed systems—especially when
 leveraging multi-agent architectures—observability becomes essential to ensure
 reliability, performance, and trust. Observability is the capability to

--- a/docs/reference-architecture/Conversational-SequenceDiagram.md
+++ b/docs/reference-architecture/Conversational-SequenceDiagram.md
@@ -1,5 +1,7 @@
 # A Conversational Sequence Diagram
 
+_Last updated: 2025-05-16_
+
 ```mermaid
 sequenceDiagram
     participant User

--- a/docs/reference-architecture/Patterns.md
+++ b/docs/reference-architecture/Patterns.md
@@ -1,5 +1,7 @@
 # Multi-Agent Patterns Reference
 
+_Last updated: 2025-05-14_
+
 This document catalogs key design patterns used in the Multi-Agent Reference
 Architecture. Each pattern contributes to the system's modularity, scalability,
 governance, or performance.

--- a/docs/reference-architecture/Reference-Architecture.md
+++ b/docs/reference-architecture/Reference-Architecture.md
@@ -1,5 +1,7 @@
 # Reference Architecture
 
+_Last updated: 2025-05-16_
+
 The architecture below illustrates a modular and governed multi-agent system,
 supporting both local and remote agents through a central orchestration layer.
 At its core, the Orchestrator (e.g., Semantic Kernel) coordinates agent

--- a/docs/security/Security.md
+++ b/docs/security/Security.md
@@ -1,5 +1,7 @@
 # Security
 
+_Last updated: 2025-05-12_
+
 This document outlines the security considerations and best practices for
 implementing multi-agent systems in enterprise environments. The architecture
 prioritizes responsible AI usage, data protection, access control, and

--- a/docs/security/Threat-Model.md
+++ b/docs/security/Threat-Model.md
@@ -1,5 +1,7 @@
 # Multi-Agent Threat Model Worksheet
 
+_Last updated: 2025-05-12_
+
 This worksheet outlines potential threats and mitigation strategies for
 multi-agent systems in enterprise environments. It follows the STRIDE
 methodology (Spoofing, Tampering, Repudiation, Information Disclosure, Denial of

--- a/scripts/update-last-updated-notice.sh
+++ b/scripts/update-last-updated-notice.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+BRANCH="main"
+git fetch origin
+
+# Get list of changed files since last push (relative to remote)
+CHANGED=$(git diff --name-only origin/$BRANCH...HEAD)
+
+# Go through all .md files under docs/
+FILES=$(find docs/ -type f -name '*.md')
+
+for FILE in $FILES; do
+	if [ ! -f "$FILE" ]; then
+		echo "❌ File not found: $FILE"
+		continue
+	fi
+
+	# Get latest Git commit date for the file
+	DATE=$(git log -1 --date=short --format="%ad" -- "$FILE")
+	if [ -z "$DATE" ]; then
+		DATE=$(date +%F)
+		echo "ℹ️  $FILE is uncommitted — using today's date: $DATE"
+	fi
+
+	# Backup the file
+	cp "$FILE" "$FILE.bak"
+
+	# Check if it already has a "Last updated" line
+	if grep -q "^_Last updated:" "$FILE"; then
+		if echo "$CHANGED" | grep -q "^$FILE$"; then
+			# It's changed → update the existing line
+			awk -v date="$DATE" '
+        BEGIN { updated = 0 }
+        /^# / {
+          print
+          getline
+          if ($0 ~ /^_Last updated:/) {
+            print "\n_Last updated: " date "_"
+            updated = 1
+          } else {
+            print $0
+            print "_Last updated: " date "_"
+            updated = 1
+          }
+          next
+        }
+        { print }
+      ' "$FILE.bak" >"$FILE"
+			echo "🔁 Updated: $FILE → $DATE"
+		else
+			echo "✅ No change: $FILE — last updated line preserved"
+		fi
+	else
+		# No existing line → insert after first header
+		awk -v date="$DATE" '
+      BEGIN { inserted = 0 }
+      /^# / {
+        print
+        print "\n_Last updated: " date "_"
+        inserted = 1
+        next
+      }
+      { print }
+    ' "$FILE.bak" >"$FILE"
+		echo "➕ Added: $FILE → $DATE"
+	fi
+
+	rm -f "$FILE.bak"
+done


### PR DESCRIPTION
This PR introduces a bash script to add a `Last updated: YYYY-MM-DD` notice on the documentation pages, addressing the issue #26.

## How it works

For every Markdown file in `docs/`:
* If it has no `_Last updated` notice: line, the script inserts it with the git last-modified date.
* If it has a notice, and the file was modified since the last push, the script updates it.
* If the file has not changed and already has the line, the script skips it.

> A PR pipeline can be added in another PR to always run the script as a validation check.