### PR TITLE
GitHub star and feedback buttons on book pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Multi-Agent Reference Architecture
 
+<a class="github-button" href="https://github.com/microsoft/multi-agent-reference-architecture" data-icon="octicon-star" data-size="large" data-show-count="true" aria-label="Give us a start on GitHub">Star</a>
+
+<script async defer src="https://buttons.github.io/buttons.js"></script>
+
 This repository presents a conceptual guide, complemented by practical
 resources, for architecting robust multi-agent systems. The focus is not on
 building an individual agent, but on the unique challenges and effectiveness of

--- a/docs/Contributors.md
+++ b/docs/Contributors.md
@@ -9,3 +9,7 @@ _Last updated: 2025-05-14_
 | [Fernando de Oliveira](https://github.com/fedeoliv) |
 | [Thiago Rotta](https://github.com/rottathiago)      |
 | [Vinicius Souza](https://github.com/ViniciusSouza)  |
+
+
+---
+<a class="github-button" href="https://github.com/microsoft/multi-agent-reference-architecture/discussions/new?category=q-a&body=Source: [Contributors](https://github.com/microsoft/multi-agent-reference-architecture/blob/main/docs/Contributors.md)" data-icon="octicon-comment-discussion" target="_blank" data-size="large" aria-label="Discuss buttons/github-buttons on GitHub">Discuss this page</a>  <script async defer src="https://buttons.github.io/buttons.js"></script>

--- a/docs/Introduction.md
+++ b/docs/Introduction.md
@@ -41,3 +41,7 @@ foundations rather than rigid requirements:
 | Context Management                        | Establish clear rules and policies regarding what context or conversational state is shared among agents and for how long. Carefully control context propagation to avoid privacy issues, data leakage, or logic confusion.                                                                                                                                                                                             |
 
 <!-- markdownlint-disable MD013 -->
+
+
+---
+<a class="github-button" href="https://github.com/microsoft/multi-agent-reference-architecture/discussions/new?category=q-a&body=Source: [Introduction](https://github.com/microsoft/multi-agent-reference-architecture/blob/main/docs/Introduction.md)" data-icon="octicon-comment-discussion" target="_blank" data-size="large" aria-label="Discuss buttons/github-buttons on GitHub">Discuss this page</a>  <script async defer src="https://buttons.github.io/buttons.js"></script>

--- a/docs/References.md
+++ b/docs/References.md
@@ -57,3 +57,7 @@ _Last updated: 2025-05-29_
 - [ACP Agent Detail Specification](https://agentcommunicationprotocol.dev/core-concepts/agent-detail)
 - [ACP Agent Detail Spec](https://agentcommunicationprotocol.dev/core-concepts/agent-detail#schema-metadata)
 - [ACP Documentation on Agent Registry](https://agentcommunicationprotocol.dev/core-concepts/agent-discovery#registry-based-discovery)
+
+
+---
+<a class="github-button" href="https://github.com/microsoft/multi-agent-reference-architecture/discussions/new?category=q-a&body=Source: [References](https://github.com/microsoft/multi-agent-reference-architecture/blob/main/docs/References.md)" data-icon="octicon-comment-discussion" target="_blank" data-size="large" aria-label="Discuss buttons/github-buttons on GitHub">Discuss this page</a>  <script async defer src="https://buttons.github.io/buttons.js"></script>

--- a/docs/agent-registry/Agent-Registry.md
+++ b/docs/agent-registry/Agent-Registry.md
@@ -178,3 +178,7 @@ for a detailed walkthrough.
 
 - [Google's Public A2A Agent Registry](https://a2astore.co/)
 - [ACP Documentation on Agent Registry](https://agentcommunicationprotocol.dev/core-concepts/agent-discovery#registry-based-discovery)
+
+
+---
+<a class="github-button" href="https://github.com/microsoft/multi-agent-reference-architecture/discussions/new?category=q-a&body=Source: [Agent Registry](https://github.com/microsoft/multi-agent-reference-architecture/blob/main/docs/agent-registry/Agent-Registry.md)" data-icon="octicon-comment-discussion" target="_blank" data-size="large" aria-label="Discuss buttons/github-buttons on GitHub">Discuss this page</a>  <script async defer src="https://buttons.github.io/buttons.js"></script>

--- a/docs/agents-communication/Agents-Communication.md
+++ b/docs/agents-communication/Agents-Communication.md
@@ -65,3 +65,7 @@ Usage example with Semantic Kernel -
 - [Agent Network Protocol (ANP)](https://agent-network-protocol.com/)
 
 - [Agent Communication Protocol (ACP)](https://agentcommunicationprotocol.dev/introduction/welcome)
+
+
+---
+<a class="github-button" href="https://github.com/microsoft/multi-agent-reference-architecture/discussions/new?category=q-a&body=Source: [Agents Communication](https://github.com/microsoft/multi-agent-reference-architecture/blob/main/docs/agents-communication/Agents-Communication.md)" data-icon="octicon-comment-discussion" target="_blank" data-size="large" aria-label="Discuss buttons/github-buttons on GitHub">Discuss this page</a>  <script async defer src="https://buttons.github.io/buttons.js"></script>

--- a/docs/building-blocks/Building-Blocks.md
+++ b/docs/building-blocks/Building-Blocks.md
@@ -64,3 +64,7 @@ stateDiagram
 
 > Additional reference of orchestration patterns:
 > [Semantic Kernel: Multi-agent Orchestration](https://devblogs.microsoft.com/semantic-kernel/semantic-kernel-multi-agent-orchestration/)
+
+
+---
+<a class="github-button" href="https://github.com/microsoft/multi-agent-reference-architecture/discussions/new?category=q-a&body=Source: [Building Blocks](https://github.com/microsoft/multi-agent-reference-architecture/blob/main/docs/building-blocks/Building-Blocks.md)" data-icon="octicon-comment-discussion" target="_blank" data-size="large" aria-label="Discuss buttons/github-buttons on GitHub">Discuss this page</a>  <script async defer src="https://buttons.github.io/buttons.js"></script>

--- a/docs/design-options/Design-Options.md
+++ b/docs/design-options/Design-Options.md
@@ -18,3 +18,7 @@ maintainability, team coordination, and operational complexity. This
 documentation explores those trade-offs and offers guidance to help you choose
 and implement the right architecture for your multi-agent system—based not only
 on technical goals, but also on your organization's structure and team dynamics.
+
+
+---
+<a class="github-button" href="https://github.com/microsoft/multi-agent-reference-architecture/discussions/new?category=q-a&body=Source: [Design Options](https://github.com/microsoft/multi-agent-reference-architecture/blob/main/docs/design-options/Design-Options.md)" data-icon="octicon-comment-discussion" target="_blank" data-size="large" aria-label="Discuss buttons/github-buttons on GitHub">Discuss this page</a>  <script async defer src="https://buttons.github.io/buttons.js"></script>

--- a/docs/design-options/Microservices.md
+++ b/docs/design-options/Microservices.md
@@ -129,3 +129,7 @@ Consider starting with microservices in the following situations:
 
 - [Microservices Guide](https://martinfowler.com/microservices/)
 - [Microservices Patterns](https://microservices.io/patterns/index.html)
+
+
+---
+<a class="github-button" href="https://github.com/microsoft/multi-agent-reference-architecture/discussions/new?category=q-a&body=Source: [Microservices](https://github.com/microsoft/multi-agent-reference-architecture/blob/main/docs/design-options/Microservices.md)" data-icon="octicon-comment-discussion" target="_blank" data-size="large" aria-label="Discuss buttons/github-buttons on GitHub">Discuss this page</a>  <script async defer src="https://buttons.github.io/buttons.js"></script>

--- a/docs/design-options/Modular-Monolith.md
+++ b/docs/design-options/Modular-Monolith.md
@@ -138,3 +138,7 @@ it.
 - [Monolith First by Martin Fowler](https://martinfowler.com/bliki/MonolithFirst.html)
 - [Microservices for Greenfield?](https://samnewman.io/blog/2015/04/07/microservices-for-greenfield/)
 - [The Onion Architecture](https://jeffreypalermo.com/2008/07/the-onion-architecture-part-1/)
+
+
+---
+<a class="github-button" href="https://github.com/microsoft/multi-agent-reference-architecture/discussions/new?category=q-a&body=Source: [Modular Monolith](https://github.com/microsoft/multi-agent-reference-architecture/blob/main/docs/design-options/Modular-Monolith.md)" data-icon="octicon-comment-discussion" target="_blank" data-size="large" aria-label="Discuss buttons/github-buttons on GitHub">Discuss this page</a>  <script async defer src="https://buttons.github.io/buttons.js"></script>

--- a/docs/governance/Experimentation-To-Productization.md
+++ b/docs/governance/Experimentation-To-Productization.md
@@ -138,3 +138,7 @@ and enables faster time-to-market.
 As organizational maturity increases, these transitions become more streamlined
 and automated—empowering continuous innovation and unlocking the full potential
 of agent-based systems in real-world deployments.
+
+
+---
+<a class="github-button" href="https://github.com/microsoft/multi-agent-reference-architecture/discussions/new?category=q-a&body=Source: [Experimentation To Productization](https://github.com/microsoft/multi-agent-reference-architecture/blob/main/docs/governance/Experimentation-To-Productization.md)" data-icon="octicon-comment-discussion" target="_blank" data-size="large" aria-label="Discuss buttons/github-buttons on GitHub">Discuss this page</a>  <script async defer src="https://buttons.github.io/buttons.js"></script>

--- a/docs/governance/Governance.md
+++ b/docs/governance/Governance.md
@@ -110,3 +110,7 @@ roadmap as follows:
 
 - Ensure users and stakeholders understand system capabilities and boundaries,
   particularly in customer-facing scenarios.
+
+
+---
+<a class="github-button" href="https://github.com/microsoft/multi-agent-reference-architecture/discussions/new?category=q-a&body=Source: [Governance](https://github.com/microsoft/multi-agent-reference-architecture/blob/main/docs/governance/Governance.md)" data-icon="octicon-comment-discussion" target="_blank" data-size="large" aria-label="Discuss buttons/github-buttons on GitHub">Discuss this page</a>  <script async defer src="https://buttons.github.io/buttons.js"></script>

--- a/docs/memory/Memory.md
+++ b/docs/memory/Memory.md
@@ -17,3 +17,7 @@ Designing STM and LTM in multi-agent systems brings unique challenges around
 synchronization, ownership, privacy, and data consistency. The following
 sections outline key patterns and trade-offs for integrating effective memory
 into your architecture.
+
+
+---
+<a class="github-button" href="https://github.com/microsoft/multi-agent-reference-architecture/discussions/new?category=q-a&body=Source: [Memory](https://github.com/microsoft/multi-agent-reference-architecture/blob/main/docs/memory/Memory.md)" data-icon="octicon-comment-discussion" target="_blank" data-size="large" aria-label="Discuss buttons/github-buttons on GitHub">Discuss this page</a>  <script async defer src="https://buttons.github.io/buttons.js"></script>

--- a/docs/memory/Short-Term-Memory.md
+++ b/docs/memory/Short-Term-Memory.md
@@ -274,3 +274,7 @@ a set number of days. This practice serves several key purposes:
    documents from STM to a cold storage.
 3. **Indexing for Analytics:** Optionally, batch-load archived data into an
    analytics warehouse for reporting and custom queries.
+
+
+---
+<a class="github-button" href="https://github.com/microsoft/multi-agent-reference-architecture/discussions/new?category=q-a&body=Source: [Short Term Memory](https://github.com/microsoft/multi-agent-reference-architecture/blob/main/docs/memory/Short-Term-Memory.md)" data-icon="octicon-comment-discussion" target="_blank" data-size="large" aria-label="Discuss buttons/github-buttons on GitHub">Discuss this page</a>  <script async defer src="https://buttons.github.io/buttons.js"></script>

--- a/docs/observability/Observability.md
+++ b/docs/observability/Observability.md
@@ -29,3 +29,7 @@ For reference:
 - [Open Telemetry Signals Concepts](https://opentelemetry.io/docs/concepts/signals/)
 - [What is OpenTelemetry?](https://opentelemetry.io/docs/what-is-opentelemetry/)
 - [OpenTelemetry – an open standard for collecting telemetry data.](https://opentelemetry.io/)
+
+
+---
+<a class="github-button" href="https://github.com/microsoft/multi-agent-reference-architecture/discussions/new?category=q-a&body=Source: [Observability](https://github.com/microsoft/multi-agent-reference-architecture/blob/main/docs/observability/Observability.md)" data-icon="octicon-comment-discussion" target="_blank" data-size="large" aria-label="Discuss buttons/github-buttons on GitHub">Discuss this page</a>  <script async defer src="https://buttons.github.io/buttons.js"></script>

--- a/docs/reference-architecture/Conversational-SequenceDiagram.md
+++ b/docs/reference-architecture/Conversational-SequenceDiagram.md
@@ -50,3 +50,7 @@ sequenceDiagram
     Orch-->>UserApp: 28. Return response
     UserApp-->>User: 29. Display answer
 ```
+
+
+---
+<a class="github-button" href="https://github.com/microsoft/multi-agent-reference-architecture/discussions/new?category=q-a&body=Source: [Conversational Sequencediagram](https://github.com/microsoft/multi-agent-reference-architecture/blob/main/docs/reference-architecture/Conversational-SequenceDiagram.md)" data-icon="octicon-comment-discussion" target="_blank" data-size="large" aria-label="Discuss buttons/github-buttons on GitHub">Discuss this page</a>  <script async defer src="https://buttons.github.io/buttons.js"></script>

--- a/docs/reference-architecture/Patterns.md
+++ b/docs/reference-architecture/Patterns.md
@@ -212,3 +212,7 @@ sequenceDiagram
     Skill 2-->>Orchestrator: Output 2
     Orchestrator->>Memory: Save updated context
 ```
+
+
+---
+<a class="github-button" href="https://github.com/microsoft/multi-agent-reference-architecture/discussions/new?category=q-a&body=Source: [Patterns](https://github.com/microsoft/multi-agent-reference-architecture/blob/main/docs/reference-architecture/Patterns.md)" data-icon="octicon-comment-discussion" target="_blank" data-size="large" aria-label="Discuss buttons/github-buttons on GitHub">Discuss this page</a>  <script async defer src="https://buttons.github.io/buttons.js"></script>

--- a/docs/reference-architecture/Reference-Architecture.md
+++ b/docs/reference-architecture/Reference-Architecture.md
@@ -345,3 +345,7 @@ List of patterns that guided the proposed architecture.
 8. Conversation-Aware Agent Orchestration (Contextual state + history memory)
 9. Agent to Agent communication
    [Agent to Agent Communication Patterns](./docs/Multi-Agent-Patterns.md#9-agent-to-agent-communication)
+
+
+---
+<a class="github-button" href="https://github.com/microsoft/multi-agent-reference-architecture/discussions/new?category=q-a&body=Source: [Reference Architecture](https://github.com/microsoft/multi-agent-reference-architecture/blob/main/docs/reference-architecture/Reference-Architecture.md)" data-icon="octicon-comment-discussion" target="_blank" data-size="large" aria-label="Discuss buttons/github-buttons on GitHub">Discuss this page</a>  <script async defer src="https://buttons.github.io/buttons.js"></script>

--- a/docs/security/Security.md
+++ b/docs/security/Security.md
@@ -128,3 +128,7 @@ guide
 
 For implementation details and threat modeling scenarios, refer to the
 [Threat Model Worksheet](./the).
+
+
+---
+<a class="github-button" href="https://github.com/microsoft/multi-agent-reference-architecture/discussions/new?category=q-a&body=Source: [Security](https://github.com/microsoft/multi-agent-reference-architecture/blob/main/docs/security/Security.md)" data-icon="octicon-comment-discussion" target="_blank" data-size="large" aria-label="Discuss buttons/github-buttons on GitHub">Discuss this page</a>  <script async defer src="https://buttons.github.io/buttons.js"></script>

--- a/docs/security/Threat-Model.md
+++ b/docs/security/Threat-Model.md
@@ -80,3 +80,7 @@ vector data. **Mitigation:**
 
 For implementation guidance and control validation, refer to the
 [Security Architecture Guide](./Multi-agent-security.md).
+
+
+---
+<a class="github-button" href="https://github.com/microsoft/multi-agent-reference-architecture/discussions/new?category=q-a&body=Source: [Threat Model](https://github.com/microsoft/multi-agent-reference-architecture/blob/main/docs/security/Threat-Model.md)" data-icon="octicon-comment-discussion" target="_blank" data-size="large" aria-label="Discuss buttons/github-buttons on GitHub">Discuss this page</a>  <script async defer src="https://buttons.github.io/buttons.js"></script>

--- a/scripts/add_ui_elements.py
+++ b/scripts/add_ui_elements.py
@@ -1,0 +1,85 @@
+import os
+import logging
+from concurrent.futures import ThreadPoolExecutor
+
+REPO_URL = "https://github.com/microsoft/multi-agent-reference-architecture"
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+DOCS_DIR = os.path.normpath(os.path.join(SCRIPT_DIR, "..", "docs"))
+
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+
+def format_title(filename: str) -> str:
+    base = os.path.splitext(filename)[0]
+    return base.replace("-", " ").replace("_", " ").title()
+
+
+def add_or_update_github_discussions_button(
+    file: str, abs_file_path: str, content: str
+):
+    rel_file_path = os.path.relpath(abs_file_path, os.path.dirname(DOCS_DIR)).replace(
+        "\\", "/"
+    )
+
+    title = format_title(file)
+
+    new_snippet = (
+        f'---\n<a class="github-button" '
+        f'href="{REPO_URL}/discussions/new?category=q-a&body=Source: [{title}]({REPO_URL}/blob/main/{rel_file_path})" '
+        f'data-icon="octicon-comment-discussion" target="_blank" data-size="large" '
+        f'aria-label="Discuss buttons/github-buttons on GitHub">Discuss this page</a>  '
+        f'<script async defer src="https://buttons.github.io/buttons.js"></script>'
+    ).strip()
+
+    github_button_header = '---\n<a class="github-button"'
+    idx = content.rfind(github_button_header)
+
+    if idx == -1:
+        with open(abs_file_path, "a", encoding="utf-8") as f:
+            _ = f.write("\n\n" + new_snippet)
+        logging.info(f"🆕 Discussions button added to {rel_file_path}")
+        return
+
+    old_snippet = content[idx:].strip()
+
+    if old_snippet == new_snippet:
+        logging.info(
+            f"✅ Discussions button already present and up to date in {rel_file_path}"
+        )
+        return
+
+    new_content = content[:idx].rstrip() + "\n\n" + new_snippet
+
+    with open(abs_file_path, "w", encoding="utf-8") as f:
+        _ = f.write(new_content)
+
+    logging.info(f"🔄 Discussions button replaced in {rel_file_path}")
+
+
+def process_single_md_file(item: tuple[str, str]):
+    directory, file = item
+    abs_file_path = os.path.join(directory, file)
+
+    with open(abs_file_path, encoding="utf-8") as f:
+        content = f.read()
+
+    add_or_update_github_discussions_button(
+        file=file,
+        abs_file_path=abs_file_path,
+        content=content,
+    )
+
+
+def process_md_files(max_workers: int = 8):
+    md_files: list[tuple[str, str]] = [
+        (root, file)
+        for root, _, files in os.walk(DOCS_DIR)
+        for file in files
+        if file.endswith(".md")
+    ]
+
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        _ = executor.map(process_single_md_file, md_files)
+
+
+if __name__ == "__main__":
+    process_md_files()


### PR DESCRIPTION
This PR introduces:

1. A GitHub start button on the first page of the book:

   <img width="800" alt="image" src="https://github.com/user-attachments/assets/f0c54a87-e6e0-44e0-96e8-e6915a997dee" />

2. `Discuss this page` button at the end of each page, which redirects the user to create a new GitHub Discussion, automatically adding the Markdown page as the source content on the body:

   <img width="842" alt="image" src="https://github.com/user-attachments/assets/1b262357-7b0c-436a-a174-623406460b96" />

   <img width="1306" alt="image" src="https://github.com/user-attachments/assets/4ac22a2e-968b-4cd3-8493-34cd634ade28" />

