### PR TITLE
Fix double stars badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Multi-Agent Reference Architecture
 
-{{ #include components/stars-badge.hbs }}
-
 [![GitHub stars](https://img.shields.io/github/stars/microsoft/multi-agent-reference-architecture?style=social)](https://github.com/microsoft/multi-agent-reference-architecture/stargazers)
 
 This repository presents a conceptual guide, complemented by practical

--- a/components/stars-badge.hbs
+++ b/components/stars-badge.hbs
@@ -1,3 +1,0 @@
-<a class="github-button" href="https://github.com/microsoft/multi-agent-reference-architecture" data-icon="octicon-star" data-size="large" data-show-count="true" aria-label="Give us a star on GitHub">Star</a>
-
-<script async defer src="https://buttons.github.io/buttons.js"></script>


### PR DESCRIPTION
This pull request removes the `stars-badge` component from the repository and updates the `README.md` file to directly include a GitHub stars badge.

![image](https://github.com/user-attachments/assets/7ec33123-ccc6-4636-b49d-e68718aa1b95)
