### PR TITLE
Fix: Add Reference Architecture correct link on README.md to avoid 40…

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,19 +29,19 @@ architectures or build them from the ground up.
 > matures.
 
 If you want to jump straight to the architecture reference, check out the
-[Reference Architecture](./docs/reference-architecture/Reference-Architecture.md)
+[Reference Architecture](docs/reference-architecture/Reference-Architecture.md)
 chapter. Otherwise, if you'd like to explore the concepts and recommendations in
 more detail, just keep reading the next chapters.
 
 ## Table of Content
 
-- [Introduction](./docs/Introduction.md)
-- [Building blocks](./docs/building-blocks/Building-Blocks.md)
-- [Design options](./docs/design-options/Design-Options.md)
-- [Agents registry](./docs/agent-registry/Agent-Registry.md)
-- [Memory](./docs/memory/Memory.md)
-- [Agents communication](./docs/agents-communication/Agents-Communication.md)
-- [Observability](./docs/observability/Observability.md)
-- [Security](./docs/security/Security.md)
-- [Governance](./docs/governance/Governance.md)
-- [Reference Architecture](./docs/reference-architecture/Reference-Architecture.md)
+- [Introduction](docs/Introduction.md)
+- [Building blocks](docs/building-blocks/Building-Blocks.md)
+- [Design options](docs/design-options/Design-Options.md)
+- [Agents registry](docs/agent-registry/Agent-Registry.md)
+- [Memory](docs/memory/Memory.md)
+- [Agents communication](docs/agents-communication/Agents-Communication.md)
+- [Observability](docs/observability/Observability.md)
+- [Security](docs/security/Security.md)
+- [Governance](docs/governance/Governance.md)
+- [Reference Architecture](docs/reference-architecture/Reference-Architecture.md)

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ architectures or build them from the ground up.
 > matures.
 
 If you want to jump straight to the architecture reference, check out the
-[Reference Architecture](/docs/reference-architecture/Reference-Architecture.md)
+[Reference Architecture](./docs/reference-architecture/Reference-Architecture.md)
 chapter. Otherwise, if you'd like to explore the concepts and recommendations in
 more detail, just keep reading the next chapters.
 

--- a/README.md
+++ b/README.md
@@ -35,13 +35,13 @@ more detail, just keep reading the next chapters.
 
 ## Table of Content
 
-- [Introduction](docs/Introduction.md)
-- [Building blocks](docs/building-blocks/Building-Blocks.md)
+- [Introduction](./docs/Introduction.md)
+- [Building blocks](./docs/building-blocks/Building-Blocks.md)
 - [Design options](./docs/design-options/Design-Options.md)
 - [Agents registry](./docs/agent-registry/Agent-Registry.md)
 - [Memory](./docs/memory/Memory.md)
-- [Agents communication](docs/agents-communication/Agents-Communication.md)
-- [Observability](docs/observability/Observability.md)
-- [Security](docs/security/Security.md)
-- [Governance](docs/governance/Governance.md)
-- [Reference Architecture](/docs/reference-architecture/Reference-Architecture.md)
+- [Agents communication](./docs/agents-communication/Agents-Communication.md)
+- [Observability](./docs/observability/Observability.md)
+- [Security](./docs/security/Security.md)
+- [Governance](./docs/governance/Governance.md)
+- [Reference Architecture](./docs/reference-architecture/Reference-Architecture.md)


### PR DESCRIPTION
This PR fixes the HTTP 404 Error not found in the [Github Page](https://microsoft.github.io/multi-agent-reference-architecture/). The Table of Contents contains references to the `docs` pages, but the Reference Architecture has a reference as if `docs`  was the root, not a relative path. This breaks the link when accessing from the Github Page.

<img width="1288" height="233" alt="image" src="https://github.com/user-attachments/assets/ac46414a-2906-4017-80de-256c4ffb5690" />
