### PR TITLE
Remove discuss button include from Memory Architecture doc

### DIFF
--- a/docs/memory/Memory-Architecture-Patterns.md
+++ b/docs/memory/Memory-Architecture-Patterns.md
@@ -302,5 +302,3 @@ See [Observability](../observability/Observability.md) and
 these signals.
 
 ---
-
-{{ #include ../../components/discuss-button.hbs }}


### PR DESCRIPTION
Removed the discuss button include from the document.